### PR TITLE
Fix childOf parameter type

### DIFF
--- a/Pod/Classes/OTTracer.h
+++ b/Pod/Classes/OTTracer.h
@@ -108,7 +108,7 @@ FOUNDATION_EXPORT NSInteger OTSpanContextCorruptedCode;
  *      value documentation
  */
 - (id<OTSpan>)startSpan:(NSString*)operationName
-                childOf:(nullable id<OTSpan>)parent
+                childOf:(nullable id<OTSpanContext>)parent
                    tags:(nullable NSDictionary*)tags;
 
 /**


### PR DESCRIPTION
OTSpan was expected whereas OTSpanContext should've been the right type.

@bensigelman pod version update and lightstep dependency update will be needed :)