### PR TITLE
-getBaggageItem: return value should be nullable

### DIFF
--- a/Pod/Classes/OTSpan.h
+++ b/Pod/Classes/OTSpan.h
@@ -101,12 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @param key the key for the Baggage item.
  * @returns nil if.f. no baggage item exists for the given key.
  */
-- (NSString*)getBaggageItem:(NSString*)key;
+- (nullable NSString*)getBaggageItem:(NSString*)key;
 
 /**
  * Mark the finish time and record this Span.
  */
-- (void) finish;
+- (void)finish;
 
 /**
  * Record this Span with the explicitly specified finish time.
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param finishTime an explicit finish timestamp; if finishTime is nil, the
  *        local walltime is used instead
  */
-- (void) finishWithTime:(nullable NSDate*)finishTime;
+- (void)finishWithTime:(nullable NSDate*)finishTime;
 
 @end
 


### PR DESCRIPTION
`-getBaggageItem` returns nil when no baggage item exists for the given key. Hence the return type should be annotated with `nullable`. Otherwise `NS_ASSUME_NONNULL` will prevent this return value to be nil. 

Also removed the spaces in front of the -finish methods - they seem out of style with to the other methods in this class, as well as other classes. 
