### PR TITLE
Span Tags should support values being strings, bools, or numeric types.

### DIFF
--- a/Pod/Classes/OTNoop.m
+++ b/Pod/Classes/OTNoop.m
@@ -24,7 +24,9 @@ static OTNoopSpanContext* g_defaultNoopSpanContext;
 - (id<OTTracer>)tracer { return g_defaultNoopTracer; }
 - (id<OTSpanContext>)context { return g_defaultNoopSpanContext; }
 - (void)setOperationName:(NSString*)operationName {}
-- (void)setTag:(NSString*)key value:(NSString*)value {}
+- (void)setTag:(NSString*)key value:(NSString *)value {}
+- (void)setTag:(NSString*)key numberValue:(NSNumber *)value {}
+- (void)setTag:(NSString*)key boolValue:(BOOL)value {}
 - (void)log:(NSDictionary<NSString*, NSObject*>*)fields {}
 - (void)log:(NSDictionary<NSString*, NSObject*>*)fields timestamp:(nullable NSDate*)timestamp {}
 - (void)logEvent:(NSString*)eventName {}

--- a/Pod/Classes/OTSpan.h
+++ b/Pod/Classes/OTSpan.h
@@ -35,9 +35,25 @@ NS_ASSUME_NONNULL_BEGIN
  * Adds a single tag to the span.
  *
  * @param key the key for the tag
- * @param value the tag's value
+ * @param value the tag's value of string type
  */
-- (void)setTag:(NSString*)key value:(NSString*)value;
+- (void)setTag:(NSString *)key value:(NSString *)value;
+
+/**
+ * Adds a single tag to the span.
+ *
+ * @param key the key for the tag
+ * @param value the tag's value of numeric type
+ */
+- (void)setTag:(NSString *)key numberValue:(NSNumber *)value;
+
+/**
+ * Adds a single tag to the span.
+ *
+ * @param key the key for the tag
+ * @param value the tag's value of boolean type
+ */
+- (void)setTag:(NSString *)key boolValue:(BOOL)value;
 
 /**
  * Log a moment in the lifetime of the OTSpan instance.


### PR DESCRIPTION
Per OpenTracing [spec](https://github.com/opentracing/specification/blob/master/specification.md),  Each Span has zero or more key:value Span Tags. The keys must be strings. **The values may be strings, bools, or numeric types.**
 
Currently ObjC interface only supports tag value being strings, not bools or numerics. Add setters to support these value types. (modeled after [Span.java](https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/Span.java) but have different method names since ObjC doesn't support method overloading. 