### PR TITLE
Add support for Carthage

### DIFF
--- a/OpenTracing Framework/Info.plist
+++ b/OpenTracing Framework/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.5.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/OpenTracing Framework/opentracing.h
+++ b/OpenTracing Framework/opentracing.h
@@ -1,0 +1,26 @@
+//
+//  OpenTracing.h
+//  OpenTracing
+//
+//  Created by Ignacio Bonafonte on 07/05/2019.
+//  Copyright © 2019 OpenTracing. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for OpenTracing.
+FOUNDATION_EXPORT double OpenTracingVersionNumber;
+
+//! Project version string for OpenTracing.
+FOUNDATION_EXPORT const unsigned char OpenTracingVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <OpenTracing/PublicHeader.h>
+
+#import <OpenTracing/OTTracer.h>
+#import <OpenTracing/OTSpanContext.h>
+#import <OpenTracing/OTSpan.h>
+#import <OpenTracing/OTNoop.h>
+#import <OpenTracing/OTGlobal.h>
+#import <OpenTracing/OTReference.h>
+#import <OpenTracing/OTVersion.h>
+

--- a/OpenTracing.xcodeproj/project.pbxproj
+++ b/OpenTracing.xcodeproj/project.pbxproj
@@ -1,0 +1,397 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6604584D2281696900639493 /* opentracing.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604584B2281696900639493 /* opentracing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586422816A3600639493 /* OTTracer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585622816A3600639493 /* OTTracer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586522816A3600639493 /* OTReference.m in Sources */ = {isa = PBXBuildFile; fileRef = 6604585722816A3600639493 /* OTReference.m */; };
+		6604586622816A3600639493 /* OTNoop.m in Sources */ = {isa = PBXBuildFile; fileRef = 6604585822816A3600639493 /* OTNoop.m */; };
+		6604586722816A3600639493 /* OTSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585922816A3600639493 /* OTSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586822816A3600639493 /* OTGlobal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6604585A22816A3600639493 /* OTGlobal.m */; };
+		6604586922816A3600639493 /* OTSpanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585B22816A3600639493 /* OTSpanContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586A22816A3600639493 /* OTVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585C22816A3600639493 /* OTVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586B22816A3600639493 /* OTTracer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6604585D22816A3600639493 /* OTTracer.m */; };
+		6604586C22816A3600639493 /* OTNoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585E22816A3600639493 /* OTNoop.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586D22816A3600639493 /* OTReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604585F22816A3600639493 /* OTReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6604586E22816A3600639493 /* OTGlobal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6604586022816A3600639493 /* OTGlobal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		660458482281696900639493 /* opentracing.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = opentracing.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6604584B2281696900639493 /* opentracing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opentracing.h; sourceTree = "<group>"; };
+		6604584C2281696900639493 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6604585622816A3600639493 /* OTTracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTTracer.h; sourceTree = "<group>"; };
+		6604585722816A3600639493 /* OTReference.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTReference.m; sourceTree = "<group>"; };
+		6604585822816A3600639493 /* OTNoop.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTNoop.m; sourceTree = "<group>"; };
+		6604585922816A3600639493 /* OTSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTSpan.h; sourceTree = "<group>"; };
+		6604585A22816A3600639493 /* OTGlobal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTGlobal.m; sourceTree = "<group>"; };
+		6604585B22816A3600639493 /* OTSpanContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTSpanContext.h; sourceTree = "<group>"; };
+		6604585C22816A3600639493 /* OTVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTVersion.h; sourceTree = "<group>"; };
+		6604585D22816A3600639493 /* OTTracer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTTracer.m; sourceTree = "<group>"; };
+		6604585E22816A3600639493 /* OTNoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTNoop.h; sourceTree = "<group>"; };
+		6604585F22816A3600639493 /* OTReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTReference.h; sourceTree = "<group>"; };
+		6604586022816A3600639493 /* OTGlobal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTGlobal.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		660458452281696900639493 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6604583E2281696900639493 = {
+			isa = PBXGroup;
+			children = (
+				6604585322816A3600639493 /* Pod */,
+				6604584A2281696900639493 /* OpenTracing Framework */,
+				660458492281696900639493 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		660458492281696900639493 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				660458482281696900639493 /* opentracing.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6604584A2281696900639493 /* OpenTracing Framework */ = {
+			isa = PBXGroup;
+			children = (
+				6604584B2281696900639493 /* opentracing.h */,
+				6604584C2281696900639493 /* Info.plist */,
+			);
+			path = "OpenTracing Framework";
+			sourceTree = "<group>";
+		};
+		6604585322816A3600639493 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				6604585422816A3600639493 /* Classes */,
+				6604586122816A3600639493 /* Assets */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		6604585422816A3600639493 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				6604585622816A3600639493 /* OTTracer.h */,
+				6604585722816A3600639493 /* OTReference.m */,
+				6604585822816A3600639493 /* OTNoop.m */,
+				6604585922816A3600639493 /* OTSpan.h */,
+				6604585A22816A3600639493 /* OTGlobal.m */,
+				6604585B22816A3600639493 /* OTSpanContext.h */,
+				6604585C22816A3600639493 /* OTVersion.h */,
+				6604585D22816A3600639493 /* OTTracer.m */,
+				6604585E22816A3600639493 /* OTNoop.h */,
+				6604585F22816A3600639493 /* OTReference.h */,
+				6604586022816A3600639493 /* OTGlobal.h */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		6604586122816A3600639493 /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		660458432281696900639493 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6604586C22816A3600639493 /* OTNoop.h in Headers */,
+				6604586E22816A3600639493 /* OTGlobal.h in Headers */,
+				6604586A22816A3600639493 /* OTVersion.h in Headers */,
+				6604586422816A3600639493 /* OTTracer.h in Headers */,
+				6604584D2281696900639493 /* opentracing.h in Headers */,
+				6604586D22816A3600639493 /* OTReference.h in Headers */,
+				6604586722816A3600639493 /* OTSpan.h in Headers */,
+				6604586922816A3600639493 /* OTSpanContext.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		660458472281696900639493 /* opentracing */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 660458502281696900639493 /* Build configuration list for PBXNativeTarget "opentracing" */;
+			buildPhases = (
+				660458432281696900639493 /* Headers */,
+				660458442281696900639493 /* Sources */,
+				660458452281696900639493 /* Frameworks */,
+				660458462281696900639493 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = opentracing;
+			productName = OpenTracing;
+			productReference = 660458482281696900639493 /* opentracing.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6604583F2281696900639493 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1020;
+				ORGANIZATIONNAME = OpenTracing;
+				TargetAttributes = {
+					660458472281696900639493 = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 660458422281696900639493 /* Build configuration list for PBXProject "OpenTracing" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 6604583E2281696900639493;
+			productRefGroup = 660458492281696900639493 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				660458472281696900639493 /* opentracing */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		660458462281696900639493 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		660458442281696900639493 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6604586622816A3600639493 /* OTNoop.m in Sources */,
+				6604586B22816A3600639493 /* OTTracer.m in Sources */,
+				6604586522816A3600639493 /* OTReference.m in Sources */,
+				6604586822816A3600639493 /* OTGlobal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6604584E2281696900639493 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6604584F2281696900639493 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		660458512281696900639493 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "OpenTracing Framework/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opentracing.opentracing;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		660458522281696900639493 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "OpenTracing Framework/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opentracing.opentracing;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		660458422281696900639493 /* Build configuration list for PBXProject "OpenTracing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6604584E2281696900639493 /* Debug */,
+				6604584F2281696900639493 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		660458502281696900639493 /* Build configuration list for PBXNativeTarget "opentracing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				660458512281696900639493 /* Debug */,
+				660458522281696900639493 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6604583F2281696900639493 /* Project object */;
+}

--- a/OpenTracing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OpenTracing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:OpenTracing.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OpenTracing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/OpenTracing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/OpenTracing.xcodeproj/xcshareddata/xcschemes/OpenTracing.xcscheme
+++ b/OpenTracing.xcodeproj/xcshareddata/xcschemes/OpenTracing.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "660458472281696900639493"
+               BuildableName = "opentracing.framework"
+               BlueprintName = "opentracing"
+               ReferencedContainer = "container:OpenTracing.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "660458472281696900639493"
+            BuildableName = "opentracing.framework"
+            BlueprintName = "opentracing"
+            ReferencedContainer = "container:OpenTracing.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "660458472281696900639493"
+            BuildableName = "opentracing.framework"
+            BlueprintName = "opentracing"
+            ReferencedContainer = "container:OpenTracing.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Add project file with the framework as only target so Carthage can locate and build the framework when referenced in the Cartfile.

It keeps the same module name and version than the framework built with Cocoapods.
We have temporarily released a version tagged 0.5.1 with these changes in our fork at https://github.com/undefinedlabs/opentracing-objc  to give support to our clients until this support is added to the official repository.