### PR TITLE
Add support for Swift Package Manager (static and dynamic library)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,11 @@ let package = Package(
     dependencies: [
     ],
     targets: [
-        .target(  name: "Opentracing", dependencies: [], path: "Pod/Classes")
+        .target(  name: "Opentracing",
+                  dependencies: [],
+                  path: "Pod",
+                  sources:["Classes"],
+                  publicHeadersPath: "SPMHeaders")
     ]
 )
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Opentracing",
+    products: [
+        .library( name: "Opentracing", type: .dynamic, targets: ["Opentracing"]),
+        .library( name: "libOpentracing", type: .static, targets: ["Opentracing"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(  name: "Opentracing", dependencies: [], path: "Pod/Classes")
+    ]
+)

--- a/Pod/Classes/OTTracer.h
+++ b/Pod/Classes/OTTracer.h
@@ -179,7 +179,7 @@ FOUNDATION_EXPORT NSInteger OTSpanContextCorruptedCode;
  * @see OTUsupportedFormatCode
  * @see OTInvalidCarrierCode
  */
-- (BOOL)inject:(id<OTSpanContext>)spanContext format:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError;
+- (BOOL)inject:(id<OTSpanContext>)spanContext format:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError NS_SWIFT_NAME(inject(spanContext:format:carrier:));
 
 /**
  * @see OTTracer#extractWithFormat:carrier:error:
@@ -221,7 +221,7 @@ FOUNDATION_EXPORT NSInteger OTSpanContextCorruptedCode;
  * @see OTSpanContextCorruptedCode
  * @see OTTracer#startSpan:references:tags:startTime:
  */
-- (nullable id<OTSpanContext>)extractWithFormat:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError;
+- (nullable id<OTSpanContext>)extractWithFormat:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError NS_SWIFT_NAME(extractWithFormat(format:carrier:));
 
 @end
 

--- a/Pod/SPMHeaders/opentracing.h
+++ b/Pod/SPMHeaders/opentracing.h
@@ -1,0 +1,26 @@
+//
+//  OpenTracing.h
+//  OpenTracing
+//
+//  Created by Ignacio Bonafonte on 07/05/2019.
+//  Copyright © 2019 OpenTracing. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for OpenTracing.
+FOUNDATION_EXPORT double OpenTracingVersionNumber;
+
+//! Project version string for OpenTracing.
+FOUNDATION_EXPORT const unsigned char OpenTracingVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <OpenTracing/PublicHeader.h>
+
+#import <./../Classes/OTTracer.h>
+#import <./../Classes/OTSpanContext.h>
+#import <./../Classes/OTSpan.h>
+#import <./../Classes/OTNoop.h>
+#import <./../Classes/OTGlobal.h>
+#import <./../Classes/OTReference.h>
+#import <./../Classes/OTVersion.h>
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/opentracing/public) [![Version](https://img.shields.io/cocoapods/v/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing) [![License](https://img.shields.io/cocoapods/l/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing) [![Platform](https://img.shields.io/cocoapods/p/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing)
+[![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/opentracing/public) [![Version](https://img.shields.io/cocoapods/v/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing) [![License](https://img.shields.io/cocoapods/l/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing) [![Platform](https://img.shields.io/cocoapods/p/opentracing.svg?style=flat)](http://cocoapods.org/pods/opentracing) [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
 
 # OpenTracing API for Objective-C
 
@@ -17,3 +17,20 @@ Use [CocoaPods](https://guides.cocoapods.org/using/getting-started.html)!
 ```ruby
 pod "opentracing"
 ```
+
+## Installation (Carthage)
+
+Use [Carthage](https://github.com/Carthage/Carthage#quick-start)!
+
+```ruby
+github "opentracing/opentracing-objc"
+```
+
+## Installation (SwiftPM)
+
+ ```swift
+ dependencies: [
+     .package(url: "https://github.com/opentracing/opentracing-objc", from: "0.5.2")
+ ]
+ ```
+

--- a/opentracing.podspec
+++ b/opentracing.podspec
@@ -1,7 +1,7 @@
 # GENERATED FILE: DO NOT EDIT DIRECTLY
 Pod::Spec.new do |s|
   s.name             = "opentracing"
-  s.version          = "0.5.1"
+  s.version          = "0.5.2"
   s.summary          = "The OpenTracing API for Objective-C"
 
   s.description      = <<-DESC


### PR DESCRIPTION
Add installation instructions for SwiftPM and Carthage
It would be nice having a version that just start supporting SPM, so I already updated version for podspec, but it can be reverted if maintainers prefer so